### PR TITLE
Add parameters and functions to allow image rotation in x and y axis

### DIFF
--- a/include/arena_camera/arena_cameras_handler.h
+++ b/include/arena_camera/arena_cameras_handler.h
@@ -66,6 +66,10 @@ public:
 
   bool get_use_default_device_settings();
 
+  void set_reverse_image_y(bool image_horizontal_flip);
+
+  void set_reverse_image_x(bool image_vertical_flip);
+
 private:
   ArenaCamera * m_cameras;
 

--- a/include/arena_camera/camera_settings.h
+++ b/include/arena_camera/camera_settings.h
@@ -27,7 +27,8 @@ public:
     const std::string & camera_name, const std::string & frame_id, const std::string & pixel_format,
     uint32_t serial_no, uint32_t fps, uint32_t horizontal_binning, uint32_t vertical_binning,
     const std::string & url_camera_info, bool exposure_auto, float exposure_value, bool gain_auto,
-    float gain_value, float gamma_value, bool enable_rectifying, bool enable_compressing, bool use_default_device_settings)
+    float gain_value, float gamma_value, bool enable_rectifying, bool enable_compressing, bool use_default_device_settings,
+    bool image_horizontal_flip, bool image_vertical_flip)
   : m_camera_name{camera_name},
     m_frame_id{frame_id},
     m_pixel_format{pixel_format},
@@ -43,7 +44,9 @@ public:
     m_gamma_value{gamma_value},
     m_enable_rectifying{enable_rectifying},
     m_enable_compressing{enable_compressing},
-    m_use_default_device_settings{use_default_device_settings}
+    m_use_default_device_settings{use_default_device_settings},
+    m_image_horizontal_flip{image_horizontal_flip},
+    m_image_vertical_flip{image_vertical_flip}
   {
     std::cout << "Camera readed from yaml file. Camera Name:" << m_camera_name
               << " Frame id:" << m_frame_id << " Serial no:" << m_serial_no
@@ -94,6 +97,16 @@ public:
   {
     m_use_default_device_settings = use_default_device_settings;
   }
+  bool get_image_horizontal_flip() { return m_image_horizontal_flip; }
+  void set_image_horizontal_flip(bool image_horizontal_flip)
+  {
+    m_image_horizontal_flip = image_horizontal_flip;
+  }
+  bool get_image_vertical_flip() { return m_image_vertical_flip; }
+  void set_image_vertical_flip(bool image_vertical_flip)
+  {
+    m_image_vertical_flip = image_vertical_flip;
+  }
 
 private:
   std::string m_url_camera_info;
@@ -112,6 +125,8 @@ private:
   bool m_enable_rectifying;
   bool m_enable_compressing;
   bool m_use_default_device_settings;
+  bool m_image_horizontal_flip;
+  bool m_image_vertical_flip;
 };
 
 #endif  // BUILD_CAMERA_SETTINGS_H

--- a/param/test.param.yaml
+++ b/param/test.param.yaml
@@ -18,5 +18,7 @@
     gain_auto: true
     gain_target: 1
     gamma_target: 1.0
+    image_horizontal_flip: false
+    image_vertical_flip: false
 
 

--- a/src/arena_camera_node.cpp
+++ b/src/arena_camera_node.cpp
@@ -99,7 +99,10 @@ CameraSetting ArenaCameraNode::read_camera_settings()
     declare_parameter<float>("gamma_target"),
     declare_parameter<bool>("enable_rectifying"),
     declare_parameter<bool>("enable_compressing"),
-    declare_parameter<bool>("use_default_device_settings"));
+    declare_parameter<bool>("use_default_device_settings"),
+    declare_parameter<bool>("image_horizontal_flip"),
+    declare_parameter<bool>("image_vertical_flip")
+    );
 
   return camera_setting;
 }

--- a/src/arena_cameras_handler.cpp
+++ b/src/arena_cameras_handler.cpp
@@ -53,6 +53,8 @@ void ArenaCamerasHandler::create_camera_from_settings(CameraSetting & camera_set
       this->set_auto_gain(camera_settings.get_enable_exposure_auto());
       this->set_gain_value(camera_settings.get_auto_gain_value());
       this->set_gamma_value(camera_settings.get_gamma_value());
+      this->set_reverse_image_y(camera_settings.get_image_horizontal_flip());
+      this->set_reverse_image_x(camera_settings.get_image_vertical_flip());
     }
 
     m_cameras = new ArenaCamera(m_device, camera_settings);
@@ -246,4 +248,43 @@ void ArenaCamerasHandler::set_use_default_device_settings(bool use_default_devic
 bool ArenaCamerasHandler::get_use_default_device_settings()
 {
   return m_use_default_device_settings;
+}
+void ArenaCamerasHandler::set_reverse_image_y(bool image_horizontal_flip)
+{
+
+  if(m_use_default_device_settings){
+    RCLCPP_WARN(
+      rclcpp::get_logger("ARENA_CAMERA_HANDLER"),
+      "Not possible to set horizontal flip. Using default device settings.");
+    return;
+  }
+
+  try {
+    GenApi::CBooleanPtr pHorizontalFlip = m_device->GetNodeMap()->GetNode("ReverseY");
+    if (GenApi::IsWritable(pHorizontalFlip)) {
+      pHorizontalFlip->SetValue(image_horizontal_flip);
+    }
+  } catch (const GenICam::GenericException & e) {
+    std::cerr << "Exception occurred during ReverseY value handling: " << e.GetDescription()
+              << std::endl;
+  }
+}
+
+void ArenaCamerasHandler::set_reverse_image_x(bool image_vertical_flip)
+{
+  if (m_use_default_device_settings) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("ARENA_CAMERA_HANDLER"),
+      "Not possible to set vertical flip. Using default device settings.");
+    return;
+  }
+  try {
+    GenApi::CBooleanPtr pVerticalFlip = m_device->GetNodeMap()->GetNode("ReverseX");
+    if (GenApi::IsWritable(pVerticalFlip)) {
+      pVerticalFlip->SetValue(image_vertical_flip);
+    }
+  } catch (const GenICam::GenericException & e) {
+    std::cerr << "Exception occurred during ReverseX value handling: " << e.GetDescription()
+              << std::endl;
+  }
 }


### PR DESCRIPTION
This PR adds parameters and functions to enable image rotation on X and Y axis.

It uses the capabilities of the Arena SDK to change the `RotateX` and `RotateY` settings.

It allows to mount the cameras upside down without having to post-process the image.